### PR TITLE
fix: syntax error in nightly-2025-05-28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sftrace"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-05-28"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use object::{ Object, ObjectSection };
 use util::{ MProtect, page_size };
 
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn sftrace_setup(
     entry_slot: unsafe extern "C" fn(),
     exit_slot: unsafe extern "C" fn(),
@@ -27,7 +27,7 @@ pub extern "C" fn sftrace_setup(
     ));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn sftrace_alloc_event(
     kind: u8,
     size: usize,


### PR DESCRIPTION
1. add `rust-toolchain.toml` using nightly-2025-05-28 channel

2. fix compile error in nightly-2025-05-28
```
error: unsafe attribute used without unsafe
  --> src/lib.rs:30:3
   |
30 | #[no_mangle]
   |   ^^^^^^^^^ usage of unsafe attribute
```