### PR TITLE
feat: record setup thread only

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ and I recommend using [vizviewr](https://github.com/gaogaotiantian/viztracer)
 vizviewer --use_external_processor trace.pb.gz
 ```
 
-# License
+## Environment Variables
+
+You can configure sftrace using the following environment variables.
+
+### SFTRACE_OUTPUT_FILE
+
+Specify the output file path, which defaults to standard output.
+
+### SFTRACE_FILTER
+
+Specify the filter file path, which is used to filter the events that are recorded.
+
+### SFTRACE_SETUP_THREAD_ONLY
+
+Only record events from the thread where `sftrace_setup` function was called.
+
+## License
 
 This project is licensed under [the MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can configure sftrace using the following environment variables.
 
 ### SFTRACE_OUTPUT_FILE
 
-Specify the output file path, which defaults to standard output.
+Specify the output file path for trace logs. If not set, no events will be recorded.
 
 ### SFTRACE_FILTER
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::sync::LazyLock;
 use std::sync::atomic::{ self, AtomicU32 };
 use crate::arch::{ Args, ReturnValue };
-use crate::layout::*;
+use crate::{layout::*, SETUP_THREAD, SETUP_THREAD_ONLY};
 use crate::{ OUTPUT, FuncId };
 
 
@@ -44,6 +44,10 @@ impl Local {
         return_value: Option<&ReturnValue>,
         alloc_event: Option<&AllocEvent>,
     ) {
+        if !(SETUP_THREAD_ONLY.load(atomic::Ordering::Relaxed) && SETUP_THREAD.with(|cell| cell.get())) {
+            return;
+        }
+
         static NOW: LazyLock<Instant> = LazyLock::new(Instant::now);
 
         const CAP: usize = 4 * 1024;

--- a/src/events.rs
+++ b/src/events.rs
@@ -44,8 +44,8 @@ impl Local {
         return_value: Option<&ReturnValue>,
         alloc_event: Option<&AllocEvent>,
     ) {
-        if !(SETUP_THREAD_ONLY.load(atomic::Ordering::Relaxed) && SETUP_THREAD.get()) {
-            return;
+        if SETUP_THREAD_ONLY.load(atomic::Ordering::Relaxed) && !SETUP_THREAD.get() {
+           return;
         }
 
         static NOW: LazyLock<Instant> = LazyLock::new(Instant::now);

--- a/src/events.rs
+++ b/src/events.rs
@@ -44,7 +44,7 @@ impl Local {
         return_value: Option<&ReturnValue>,
         alloc_event: Option<&AllocEvent>,
     ) {
-        if !(SETUP_THREAD_ONLY.load(atomic::Ordering::Relaxed) && SETUP_THREAD.with(|cell| cell.get())) {
+        if !(SETUP_THREAD_ONLY.load(atomic::Ordering::Relaxed) && SETUP_THREAD.get()) {
             return;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use util::{ MProtect, page_size };
 
 pub(crate) static SETUP_THREAD_ONLY: AtomicBool = AtomicBool::new(false);
 thread_local! {
-    pub(crate) static SETUP_THREAD: Cell<bool> = Cell::new(false);
+    pub(crate) static SETUP_THREAD: Cell<bool> = const { Cell::new(false) };
 }
 
 #[unsafe(no_mangle)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub extern "C" fn sftrace_setup(
         tailcall_slot
     ));
 
-    if let Ok(key) = std::env::var("SETUP_THREAD_ONLY") && !key.is_empty() {
+    if let Ok(key) = std::env::var("SFTRACE_SETUP_THREAD_ONLY") && !key.is_empty() {
         SETUP_THREAD_ONLY.store(true, atomic::Ordering::Relaxed);
     }
     SETUP_THREAD.with(|cell| cell.set(true));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,10 @@ use std::sync::OnceLock;
 use object::{ Object, ObjectSection };
 use util::{ MProtect, page_size };
 
-pub(crate) static SETUP_THREAD_ONLY: AtomicBool = AtomicBool::new(false);
+static SETUP_THREAD_ONLY: AtomicBool = AtomicBool::new(false);
+
 thread_local! {
-    pub(crate) static SETUP_THREAD: Cell<bool> = const { Cell::new(false) };
+    static SETUP_THREAD: Cell<bool> = const { Cell::new(false) };
 }
 
 #[unsafe(no_mangle)]
@@ -36,7 +37,7 @@ pub extern "C" fn sftrace_setup(
     if let Ok(key) = std::env::var("SFTRACE_SETUP_THREAD_ONLY") && !key.is_empty() {
         SETUP_THREAD_ONLY.store(true, atomic::Ordering::Relaxed);
     }
-    SETUP_THREAD.with(|cell| cell.set(true));
+    SETUP_THREAD.set(true);
 }
 
 #[unsafe(no_mangle)]

--- a/src/tools/record.rs
+++ b/src/tools/record.rs
@@ -106,7 +106,7 @@ impl SubCommand {
         if env::var_os(LIBRARY_PATH_NAME).is_none() {
             let solib = match self.solib.as_ref() {
                 Some(p) => p.clone(),
-                None => search_sftracelib(&projdir.data_dir())?
+                None => search_sftracelib(projdir.data_dir())?
             };
 
             let libdir = solib.parent().unwrap();


### PR DESCRIPTION
This PR introduces a new environment variable `SFTRACE_SETUP_THREAD_ONLY` that allows sftrace to record events only from the thread where `sftrace_setup` was called.

**Use case**: This feature is particularly useful for analyzing NAPI performance, where we only want to focus on the JavaScript thread and filter out noise from other threads.